### PR TITLE
Update WallE.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "WallE"
 uuid = "409c7e06-86dc-11e9-30a5-6d15a9183e58"
 authors = ["CodeLenz <eduardobarplenz@gmail.com>"]
 repo-url = "https://github.com/CodeLenz/WallE.git"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/WallE.jl
+++ b/src/WallE.jl
@@ -469,14 +469,13 @@ end
           end
         end
 
-        last_f = fn
-        last_x = copy(xn)
-
       #@show iter, α, fn, first_improvement
 
       end # while
 
-
+      # Updates minimized parameters after while loop
+      last_f = fn
+      last_x = copy(xn)
 
       # Additional check. If we not improve f, than 
       # indicate and keep the original values


### PR DESCRIPTION
Estava testando o "crude LS" e percebi que ele não atualizava o `xopt`, pois as variáveis `last_f` e `last_x` estavam dentro do loop `while`.